### PR TITLE
Renamed to wikimedia-service-builder

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "service-builder",
+  "name": "wikimedia-service-builder",
   "version": "0.1.0",
   "description": "Docker-based build script for node.js services",
   "main": "index.js",


### PR DESCRIPTION
The `service-builder` is unfortunately taken on npmjs.org, so rename to `wikimedia-service-builder`